### PR TITLE
Update conda to 0.4.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,8 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,6 +1,8 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gmischl1 @rflperry
+* @gavinmischler @rflperry

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/README.md
+++ b/README.md
@@ -7,16 +7,22 @@ Package license: MIT
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/mvlearn-feedstock/blob/master/LICENSE.txt)
 
-Summary: A python package for multi-view machine learning
+Summary: A python package for multiview machine learning
 
 Development: https://github.com/mvlearn/mvlearn
 
 Documentation: https://mvlearn.github.io/
 
-mvlearn is a python package for multi-view machine learning. It offers
-a comprehensive, tested, and well-documented collection of multi-view
-learning tools, enabling anyone to readily access and apply such
-methods to their data.
+mvlearn aims to serve as a community-driven open-source software package
+that offers reference implementations for algorithms and methods related
+to multiview learning (machine learning in settings where there are
+multiple incommensurate views or feature sets for each sample). It brings
+together the most widely-used tools in this setting with a standardized
+scikit-learn like API, well tested code and high-quality documentation.
+Doing so, we aim to facilitate application, extension, and comparison of
+methods, and offer a foundation for research into new multiview algorithms.
+We welcome new contributors and the addition of methods with proven
+efficacy and current use.
 
 
 Current build status

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 About mvlearn
 =============
 
-Home: https://mvlearn.neurodata.io/
+Home: https://mvlearn.github.io/
 
-Package license: Apache-2.0
+Package license: MIT
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/mvlearn-feedstock/blob/master/LICENSE.txt)
 
 Summary: A python package for multi-view machine learning
+
+Development: https://github.com/mvlearn/mvlearn
+
+Documentation: https://mvlearn.github.io/
 
 mvlearn is a python package for multi-view machine learning. It offers
 a comprehensive, tested, and well-documented collection of multi-view
@@ -120,6 +124,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@gmischl1](https://github.com/gmischl1/)
+* [@gavinmischler](https://github.com/gavinmischler/)
 * [@rflperry](https://github.com/rflperry/)
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,8 @@ requirements:
     - graspy >=0.1.1
     - matplotlib-base >=3.0.0
     - numpy >=1.17.0
-    - pandas >=0.25.0
     - scikit-learn >=0.19.1
-    - scipy >=1.1.0
+    - scipy >=1.4.0
     - seaborn >=0.9.0
     - pytorch >=1.1.0
     - tqdm
@@ -50,12 +49,18 @@ about:
   home: https://mvlearn.github.io/
   license: MIT
   license_file: LICENSE
-  summary: 'A python package for multi-view machine learning'
+  summary: 'A python package for multiview machine learning'
   description: |
-    mvlearn is a python package for multi-view machine learning. It offers
-    a comprehensive, tested, and well-documented collection of multi-view
-    learning tools, enabling anyone to readily access and apply such
-    methods to their data.
+    mvlearn aims to serve as a community-driven open-source software package
+    that offers reference implementations for algorithms and methods related
+    to multiview learning (machine learning in settings where there are
+    multiple incommensurate views or feature sets for each sample). It brings
+    together the most widely-used tools in this setting with a standardized
+    scikit-learn like API, well tested code and high-quality documentation.
+    Doing so, we aim to facilitate application, extension, and comparison of
+    methods, and offer a foundation for research into new multiview algorithms.
+    We welcome new contributors and the addition of methods with proven
+    efficacy and current use.
   doc_url: https://mvlearn.github.io/
   dev_url: https://github.com/mvlearn/mvlearn
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "mvlearn" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/neurodata/mvlearn/releases/download/{{ version }}-torch/{{ name }}-{{ version }}.tar.gz
-  sha256: aec6c2cd6773c41d6ad9b66b82330b08a61e334f7cd0ccbea0866d00a610fefb
+  url: https://github.com/mvlearn/mvlearn/releases/download/{{ version }}-conda/{{ name }}-{{ version }}.tar.gz
+  sha256: 4a4f835704abcc19602f4c71997daafd8a0440f12644bdcfe19064c5d67e4589
 
 build:
   noarch: python
@@ -37,17 +37,18 @@ test:
   imports:
     - mvlearn
     - mvlearn.cluster
-    - mvlearn.decomposition
-    - mvlearn.semi_supervised
-    - mvlearn.construct
+    - mvlearn.compose
     - mvlearn.datasets
+    - mvlearn.decomposition
     - mvlearn.embed
+    - mvlearn.model_selection
     - mvlearn.plotting
+    - mvlearn.semi_supervised
     - mvlearn.utils
 
 about:
-  home: https://mvlearn.neurodata.io/
-  license: Apache-2.0
+  home: https://mvlearn.github.io/
+  license: MIT
   license_file: LICENSE
   summary: 'A python package for multi-view machine learning'
   description: |
@@ -55,10 +56,10 @@ about:
     a comprehensive, tested, and well-documented collection of multi-view
     learning tools, enabling anyone to readily access and apply such
     methods to their data.
-  doc_url: https://mvlearn.neurodata.io/
-  dev_url: https://github.com/neurodata/mvlearn
+  doc_url: https://mvlearn.github.io/
+  dev_url: https://github.com/mvlearn/mvlearn
 
 extra:
   recipe-maintainers:
-    - gmischl1
+    - gavinmischler
     - rflperry

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/mvlearn/mvlearn/releases/download/{{ version }}-conda/{{ name }}-{{ version }}.tar.gz
-  sha256: 4a4f835704abcc19602f4c71997daafd8a0440f12644bdcfe19064c5d67e4589
+  sha256: 70ac4f459c9a2febfd0bfa8c918de80d9a7b6e194d539a7275a2ca880515c5f5
 
 build:
   noarch: python


### PR DESCRIPTION
Updating conda to 0.4.0. TODO may need to remove `mvlearn.decomposition` in the tests imports